### PR TITLE
Ability to add SWIFT/BIC code

### DIFF
--- a/bill.go
+++ b/bill.go
@@ -290,12 +290,15 @@ func (b *Bill) drawBankDetails() {
 	b.pdf.SetFont(b.config.Business.SerifFont, "", 8)
 	headers := []string{
 		"Pay By", "Bank Name", "Address", "Account Type (checking/Savings)",
-		"IBAN (international)", "Sort Code (International)",
+		"IBAN (international)", "Sort Code (international)", "SWIFT/BIC (international)",
 	}
 
 	b.pdf.SetDrawColor(64, 64, 64)
 	b.lightFillColor()
 	for i, v := range b.config.Bank.Strings() {
+		if v == "" {
+			continue
+		}
 		b.whiteText()
 		b.pdf.SetFont(b.config.Business.SerifFont, "B", 10)
 		b.textFormat(60, 5, headers[i], "1", 0, "R", true, 0, "")

--- a/billing.example.yaml
+++ b/billing.example.yaml
@@ -41,6 +41,7 @@ bank:
   account_type:  "Checking"
   iban:          "DE99 5555 5555 5555 5555 55"
   sort_code:     "12-12-12"
+  #swift_bic:     "ABCXYZ"
 
 # Branding colors to use on the bill, assumes a light color
 # and a dark color. If you use two dark colors, it will be ugly.

--- a/config.go
+++ b/config.go
@@ -71,11 +71,12 @@ type BankDetails struct {
 	AccountType  string `yaml:"account_type"`
 	IBAN         string
 	SortCode     string `yaml:"sort_code"`
+	SWIFTBIC     string `yaml:"swift_bic"`
 }
 
 func (b *BankDetails) Strings() []string {
 	return []string{
-		b.TransferType, b.Name, b.Address, b.AccountType, b.IBAN, b.SortCode,
+		b.TransferType, b.Name, b.Address, b.AccountType, b.IBAN, b.SortCode, b.SWIFTBIC,
 	}
 }
 


### PR DESCRIPTION
Some countries use SWIFT/BIC codes instead of sort codes. This change lets you specify either (or both, even though I'm not sure that will ever be useful).