### PR TITLE
Add support for entering tax as a percentage of Total

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ are:
  * Everything on the bill is the same currency
  * Filenames will be output in a standard way
 
-Current limitations:
- * It almost has support for tax calculation but it's not there yet
-
 The Problem This Solves
 ------------------------
 

--- a/billing.example.yaml
+++ b/billing.example.yaml
@@ -33,6 +33,10 @@ billables:
     unit_price:  10.23
     currency:    €
 
+# You may enter tax as a percentage here (from 0 to 1.0).
+tax:
+  percentage: 0.1
+
 # Where to send the money!
 bank:
   # Any fields you don't specify here, will be left entirely off

--- a/invoice/bill.go
+++ b/invoice/bill.go
@@ -150,7 +150,7 @@ func (b *Bill) RenderToFile() error {
 	headers = []string{"Qty", "Description", "Unit Price", "Line Total"}
 	widths := []float64{16, 125.5, 25, 25}
 
-	b.drawBillablesTable(headers, b.config.Billables, widths)
+	b.drawBillablesTable(headers, b.config.Billables, b.config.Tax, widths)
 	b.drawBankDetails()
 
 	// It's safe to MustParse here because we validate args earlier
@@ -229,7 +229,7 @@ func (b *Bill) drawBlanks(billables []BillableItem, widths []float64) {
 
 // drawBillableaTable renders the table containing one line each
 // for the billable items described in the YAML file.
-func (b *Bill) drawBillablesTable(headers []string, billables []BillableItem, widths []float64) {
+func (b *Bill) drawBillablesTable(headers []string, billables []BillableItem, taxDetails *TaxDetails, widths []float64) {
 	b.pdf.SetFillColor(255, 0, 0)
 	b.whiteText()
 	b.pdf.SetDrawColor(64, 64, 64)
@@ -261,8 +261,7 @@ func (b *Bill) drawBillablesTable(headers []string, billables []BillableItem, wi
 	}
 
 	// Calculate tax
-	// TODO: Make this configurable.
-	tax := subTotal * 0.1
+	tax := subTotal * taxDetails.Percentage
 	total := subTotal + tax
 
 	// Draw the Sub-Total

--- a/invoice/bill.go
+++ b/invoice/bill.go
@@ -260,6 +260,11 @@ func (b *Bill) drawBillablesTable(headers []string, billables []BillableItem, wi
 		b.pdf.Ln(4)
 	}
 
+	// Calculate tax
+	// TODO: Make this configurable.
+	tax := subTotal * 0.1
+	total := subTotal + tax
+
 	// Draw the Sub-Total
 	b.pdf.SetDrawColor(255, 255, 255)
 	b.pdf.SetFont(b.config.Business.SerifFont, "", 8)
@@ -272,18 +277,19 @@ func (b *Bill) drawBillablesTable(headers []string, billables []BillableItem, wi
 	// Draw Tax
 	b.pdf.Ln(4)
 	b.drawBlanks(billables, widths)
-	b.textFormat(widths[len(widths)-2], 4, "Tax", "1", 0, "R", true, 0, "")
-	b.textFormat(widths[len(widths)-1], 4, "0", "1", 0, "R", true, 0, "")
+	taxText := billables[0].Currency + " " + niceFloatStr(tax)
+	b.textFormat(widths[len(widths)-2], 4, "GST", "1", 0, "R", true, 0, "")
+	b.textFormat(widths[len(widths)-1], 4, taxText, "1", 0, "R", true, 0, "")
 
 	// Draw Total
-	// XXX Total just uses sub-total and assumes €0.00 tax for now...
 	b.pdf.Ln(4)
 	b.drawBlanks(billables, widths)
 	b.pdf.SetFont(b.config.Business.SerifFont, "B", 10)
 	y := b.pdf.GetY()
 	x := b.pdf.GetX()
+	totalText := billables[0].Currency + " " + niceFloatStr(total)
 	b.textFormat(widths[len(widths)-2], 6, "Total", "1", 0, "R", true, 0, "")
-	b.textFormat(widths[len(widths)-1], 6, subTotalText, "1", 0, "R", true, 0, "")
+	b.textFormat(widths[len(widths)-1], 6, totalText, "1", 0, "R", true, 0, "")
 	x2 := b.pdf.GetX()
 
 	b.pdf.SetDrawColor(64, 64, 64)

--- a/invoice/config.go
+++ b/invoice/config.go
@@ -65,6 +65,10 @@ func (b *BillableItem) Strings() []string {
 	}
 }
 
+type TaxDetails struct {
+	Percentage float64
+}
+
 type BankDetails struct {
 	TransferType string `yaml:"transfer_type"`
 	Name         string
@@ -97,6 +101,7 @@ type BillingConfig struct {
 	Bill      *BillDetails     `yaml:"bill"`
 	BillTo    *BillToDetails   `yaml:"bill_to"`
 	Billables []BillableItem   `yaml:"billables"`
+	Tax       *TaxDetails      `yaml:"tax"`
 	Bank      *BankDetails     `yaml:"bank"`
 	Colors    *BillColor       `yaml:"colors"`
 }


### PR DESCRIPTION
Simple support to configure tax as a percentage of Total in the `billing.yaml` file.